### PR TITLE
Add optional envvar parameter for env variable name

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -21,6 +21,7 @@ main() {
   fi
 
   local awsregion=${AWS_DEFAULT_REGION:-us-east-1}
+  local ssmkey="${BUILDKITE_PLUGIN_SSM_SSMKEY:-}"
   local envvar="${BUILDKITE_PLUGIN_SSM_ENVVAR:-}"
   ssm_get_parameter "$ssmkey" "$awsregion" "$envvar"
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -21,8 +21,8 @@ main() {
   fi
 
   local awsregion=${AWS_DEFAULT_REGION:-us-east-1}
-  local ssmkey="${BUILDKITE_PLUGIN_SSM_SSMKEY:-}"
-  ssm_get_parameter "$ssmkey" "$awsregion"
+  local envvar="${BUILDKITE_PLUGIN_SSM_ENVVAR:-}"
+  ssm_get_parameter "$ssmkey" "$awsregion" "$envvar"
 
 }
 
@@ -81,11 +81,12 @@ credentials_json_to_shell_exports() {
 ssm_get_parameter() {
     local ssmkey="$1"
     local awsregion="$2"
+    local envvar="$3"
     echo "--- :ssm: Get SSM ${ssmkey} in region ${awsregion}"
     response=$(aws ssm get-parameters --region $awsregion --names $ssmkey --with-decryption)
     ssmValue=$(echo "$response" | jq -r '.Parameters[].Value')
     #echo "--- :ssm: SSM value ${ssmValue}"
-    export $ssmkey=$ssmValue
+    export ${envvar:-$ssmkey}=$ssmValue
 }
 
 main

--- a/plugin.yml
+++ b/plugin.yml
@@ -11,5 +11,7 @@ configuration:
       type: string
     ssmkey:
       type: string
+    envvar:
+      type: string
   required:
     - ssmkey


### PR DESCRIPTION
This PR adds an additional buildkite plugin parameter 'envvar'. With 'envvar' you can specify the name of the exported variable. The parameter is entirely optional and does not break previous behaviour.

Why is this useful?
SMM parameters can have names which contain characters which are illegal for env-variable names, e.g. `/my/parameter` would not work as `export /my/parameter=my_value` would throw an error. By specifying a custom name via 'envvar', this problem can be fixed.